### PR TITLE
Fix a bug in MHUD::getMarginal

### DIFF
--- a/lib/src/MixedHistogramUserDefined.cxx
+++ b/lib/src/MixedHistogramUserDefined.cxx
@@ -244,7 +244,8 @@ OT::Distribution MixedHistogramUserDefined::getMarginal(const OT::UnsignedIntege
     const OT::UnsignedInteger size = ticksCollection_[i].getSize();
     OT::SampleImplementation support(size, 1);
     support.setData(ticksCollection_[i]);
-    OT::UserDefined marginal(support, mixture_.getMarginal(i).getProbabilities());
+    const OT::Distribution marginalMixture(mixture_.getMarginal(i));
+    OT::UserDefined marginal(marginalMixture.getSupport(), marginalMixture.getProbabilities());
     marginal.setDescription(OT::Description(1, getDescription()[i]));
     return marginal.clone();
   }

--- a/python/test/t_plant_growth.py
+++ b/python/test/t_plant_growth.py
@@ -111,8 +111,9 @@ l_dist_wet.drawPDF()
 
 ie.addJointTarget(["Height","Moisture"])
 h_m_dist = otagrum.Utils.FromPotential(ie.jointPosterior(["Height","Moisture"]))
+print(h_m_dist)
+print(h_m_dist.getDescription())
 h_m_dist.getMarginal(0)
-
 
 
 


### PR DESCRIPTION
if kind_[i] == 0 we cant rely on Mixture::getProbabilities as some atoms
may be filtered.

cc @regislebrun 