### PR TITLE
Improved ContinuousTTest

### DIFF
--- a/lib/src/otagrum/ContinuousTTest.hxx
+++ b/lib/src/otagrum/ContinuousTTest.hxx
@@ -64,7 +64,7 @@ public:
 
 private:
   /// computes K from the sample properties (size, dimension, ...)
-  static OT::UnsignedInteger GetK(const OT::Sample & sample);
+  static OT::UnsignedInteger GetK(const OT::UnsignedInteger size, const OT::UnsignedInteger dimension);
 
   /// computes the key from Indices and k
   static std::string GetKey(const OT::Indices & l,
@@ -73,7 +73,7 @@ private:
   /// get the log-pdf of Bernstein Copula on Indice l in data
   /// if k=0 : use getK_ to find the right value
   OT::Point getLogPDF(const OT::Indices & l,
-		      const OT::UnsignedInteger k = 0) const;
+		      const OT::UnsignedInteger k) const;
 
   /// get the log-pdfs of Berstein Copulae fX,fYX,fZX,FUZX
   /// allows to call getLogPDF_ with the same k for all copulae

--- a/lib/test/t_ContinuousPC_std.expout
+++ b/lib/test/t_ContinuousPC_std.expout
@@ -5,9 +5,9 @@ digraph "skeleton" {
   edge [dir = none];
   node [shape = ellipse];
   0; 1; 2; 3; 
-  0->1 [label="174
+  0->1 [label="116
 0"]
-  2->3 [label="275
+  2->3 [label="213
 0"]
 }
 0--1 : p-value=0

--- a/lib/test/t_ContinuousTTest_std.expout
+++ b/lib/test/t_ContinuousTTest_std.expout
@@ -1,20 +1,18 @@
 Data dimension : 10
 Data size : 1300
 Cache : 
-      |1 : [0]:3, [1]:3
-      |2 : [0,1]:3
+      |2 : [0,1]:11
 
 alpha :0.1
 Data dimension : 10
 Data size : 1300
 Cache : 
-      |1 : [0]:3, [1]:3, [8]:3, [9]:3
-      |2 : [0,1]:3, [8,9]:3
+      |2 : [0,1]:11, [8,9]:11
 
 alpha :0.1
-ttest value: 0.248115    pvalue:0.804045    test: OK 
-ttest value: 12.7639    pvalue:2.60933e-37    test: OK 
-ttest value: 115.958     pvalue:0   test: OK
-ttest value: 0.488824     pvalue:0.624966   test: OK 
-ttest value: 0.238729     pvalue:0.811315   test: OK 
-ttest value: 3.25249     pvalue:0.00114397   test: fail 
+ttest value: 0.122034    pvalue:0.902872    test: OK 
+ttest value: 13.0389    pvalue:7.35388e-39    test: OK 
+ttest value: 78.6697     pvalue:0   test: OK
+ttest value: 0.35558     pvalue:0.722155   test: OK 
+ttest value: 0.168601     pvalue:0.866111   test: OK 
+ttest value: 2.80191     pvalue:0.00508016   test: fail 


### PR DESCRIPTION
+ Now, the PDF of univariate marginal copulas is no more computed as a Bernstein copula but is taken into account analytically.
+ The marginal samples are no more extracted, instead the global sample is accessed.
+ The bin number is now dependent from the current local dimension, ie the 2+d where d is the dimension of the current separator